### PR TITLE
feat: high level api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,14 @@ tokio-retry = "0.3"
 
 near-account-id = "0.17"
 near-crypto = "0.17"
+near-gas = { version = "0.2.3", features = ["serde", "borsh", "schemars"] }
 near-primitives = "0.17"
+near-token = "0.2"
 near-jsonrpc-primitives = "0.17"
 near-jsonrpc-client = { version = "0.6", default-features = false }
 
 [features]
-default = ["rustls-tls", "sandbox"]
+default = ["rustls-tls"]
 adversarial = ["near-jsonrpc-client/adversarial"]
 any = ["near-jsonrpc-client/any"]
 sandbox = ["near-jsonrpc-client/sandbox"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use near_jsonrpc_client::errors::JsonRpcError;
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
+use near_jsonrpc_primitives::types::chunks::RpcChunkError;
 use near_jsonrpc_primitives::types::query::RpcQueryError;
 use near_jsonrpc_primitives::types::transactions::RpcTransactionError;
 
@@ -13,12 +14,19 @@ pub enum Error {
     #[error(transparent)]
     RpcQueryError(#[from] JsonRpcError<RpcQueryError>),
     #[error(transparent)]
+    RpcChunkError(#[from] JsonRpcError<RpcChunkError>),
+    #[error(transparent)]
     RpcTransactionError(#[from] JsonRpcError<RpcTransactionError>),
     #[error("invalid data returned: {0}")]
-    RpcReturnedInvalidData(&'static str),
+    RpcReturnedInvalidData(String),
+    /// Catch all RPC error. This is usually resultant from query calls.
+    #[error("rpc: {0}")]
+    Rpc(Box<dyn std::error::Error + Send + Sync>),
 
     #[error(transparent)]
-    SerializeError(#[from] serde_json::Error),
+    Serialization(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
     #[error("invalid args were passed: {0}")]
     InvalidArgs(&'static str),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use near_jsonrpc_client::errors::JsonRpcError;
+use near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncError;
 use near_jsonrpc_primitives::types::blocks::RpcBlockError;
 use near_jsonrpc_primitives::types::chunks::RpcChunkError;
 use near_jsonrpc_primitives::types::query::RpcQueryError;
@@ -17,6 +18,8 @@ pub enum Error {
     RpcChunkError(#[from] JsonRpcError<RpcChunkError>),
     #[error(transparent)]
     RpcTransactionError(#[from] JsonRpcError<RpcTransactionError>),
+    #[error(transparent)]
+    RpcTransactionAsyncError(#[from] JsonRpcError<RpcBroadcastTxAsyncError>),
     #[error("invalid data returned: {0}")]
     RpcReturnedInvalidData(String),
     /// Catch all RPC error. This is usually resultant from query calls.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,16 @@ impl Client {
         }
     }
 
+    /// Internal reference to the [`JsonRpcClient`] that is utilized for all RPC calls.
+    pub fn inner(&self) -> &JsonRpcClient {
+        &self.rpc_client
+    }
+
+    /// Internal mutable reference to the [`JsonRpcClient`] that is utilized for all RPC calls.
+    pub fn inner_mut(&mut self) -> &mut JsonRpcClient {
+        &mut self.rpc_client
+    }
+
     /// The RPC address the client is connected to.
     pub fn rpc_addr(&self) -> String {
         self.rpc_client.server_addr().into()
@@ -213,6 +223,12 @@ impl Client {
     pub async fn invalidate_cache(&self, cache_key: &CacheKey) {
         let mut nonces = self.access_key_nonces.write().await;
         nonces.remove(cache_key);
+    }
+}
+
+impl Into<JsonRpcClient> for Client {
+    fn into(self) -> JsonRpcClient {
+        self.rpc_client
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,20 +39,11 @@ pub use crate::error::Error;
 pub type CacheKey = (AccountId, PublicKey);
 
 /// Client that implements exponential retrying and caching of access key nonces.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Client {
     rpc_client: JsonRpcClient,
     /// AccessKey nonces to reference when sending transactions.
     access_key_nonces: Arc<RwLock<HashMap<CacheKey, AtomicU64>>>,
-}
-
-impl Clone for Client {
-    fn clone(&self) -> Self {
-        Self {
-            rpc_client: self.rpc_client.clone(),
-            access_key_nonces: self.access_key_nonces.clone(),
-        }
-    }
 }
 
 impl Client {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,8 @@ impl Client {
         .await
     }
 
-    pub async fn send<M>(&self, method: M) -> MethodCallResult<M::Response, M::Error>
+    /// Send a JsonRpc method to the network.
+    pub(crate) async fn send<M>(&self, method: M) -> MethodCallResult<M::Response, M::Error>
     where
         M: methods::RpcMethod + Send + Sync,
         M::Response: Send,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,82 @@
+use near_gas::NearGas;
+use near_primitives::borsh;
+use near_token::NearToken;
+
+use crate::{Error, Result};
+
+pub const MAX_GAS: NearGas = NearGas::from_tgas(300);
+pub const DEFAULT_CALL_FN_GAS: NearGas = NearGas::from_tgas(10);
+pub const DEFAULT_CALL_DEPOSIT: NearToken = NearToken::from_near(0);
+
+/// A set of arguments we can provide to a transaction, containing
+/// the function name, arguments, the amount of gas to use and deposit.
+#[derive(Debug)]
+pub struct Function {
+    pub(crate) name: String,
+    pub(crate) args: Result<Vec<u8>>,
+    pub(crate) deposit: NearToken,
+    pub(crate) gas: NearGas,
+}
+
+impl Function {
+    /// Initialize a new instance of [`Function`], tied to a specific function on a
+    /// contract that lives directly on a contract we've specified in [`Transaction`].
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.into(),
+            args: Ok(vec![]),
+            deposit: DEFAULT_CALL_DEPOSIT,
+            gas: DEFAULT_CALL_FN_GAS,
+        }
+    }
+
+    /// Provide the arguments for the call. These args are serialized bytes from either
+    /// a JSON or Borsh serializable set of arguments. To use the more specific versions
+    /// with better quality of life, use `args_json` or `args_borsh`.
+    pub fn args(mut self, args: Vec<u8>) -> Self {
+        if self.args.is_err() {
+            return self;
+        }
+        self.args = Ok(args);
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is JSON serializable and can be
+    /// accepted by the equivalent contract. Recommend to use something like
+    /// `serde_json::json!` macro to easily serialize the arguments.
+    pub fn args_json<U: serde::Serialize>(mut self, args: U) -> Self {
+        match serde_json::to_vec(&args) {
+            Ok(args) => self.args = Ok(args),
+            Err(e) => self.args = Err(Error::Serialization(e)),
+        }
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is borsh serializable and can be
+    /// accepted by the equivalent contract.
+    pub fn args_borsh<U: borsh::BorshSerialize>(mut self, args: U) -> Self {
+        match args.try_to_vec() {
+            Ok(args) => self.args = Ok(args),
+            Err(e) => self.args = Err(Error::Io(e)),
+        }
+        self
+    }
+
+    /// Specify the amount of tokens to be deposited where `deposit` is the amount of
+    /// tokens in yocto near.
+    pub fn deposit(mut self, deposit: NearToken) -> Self {
+        self.deposit = deposit;
+        self
+    }
+
+    /// Specify the amount of gas to be used.
+    pub fn gas(mut self, gas: NearGas) -> Self {
+        self.gas = gas;
+        self
+    }
+
+    /// Use the maximum amount of gas possible to perform this function call into the contract.
+    pub fn max_gas(self) -> Self {
+        self.gas(MAX_GAS)
+    }
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -96,14 +96,14 @@ impl Function {
     }
 }
 
-pub struct CallableFunction<'a, S> {
+pub struct FunctionCallTransaction<'a, S> {
     pub(crate) client: &'a Client,
     pub(crate) signer: S,
     pub(crate) contract_id: AccountId,
     pub(crate) function: Function,
 }
 
-impl<S> CallableFunction<'_, S> {
+impl<S> FunctionCallTransaction<'_, S> {
     /// Provide the arguments for the call. These args are serialized bytes from either
     /// a JSON or Borsh serializable set of arguments. To use the more specific versions
     /// with better quality of life, use `args_json` or `args_borsh`.
@@ -146,25 +146,8 @@ impl<S> CallableFunction<'_, S> {
     }
 }
 
-impl Client {
-    /// Start calling into a contract on a specific function.
-    pub fn call<S: Signer + ExposeAccountId>(
-        &self,
-        signer: S,
-        contract_id: &AccountId,
-        function: &str,
-    ) -> CallableFunction<'_, S> {
-        CallableFunction {
-            client: self,
-            signer,
-            contract_id: contract_id.clone(),
-            function: Function::new(function),
-        }
-    }
-}
-
 impl<'a, S: Signer + ExposeAccountId + 'static> std::future::IntoFuture
-    for CallableFunction<'a, S>
+    for FunctionCallTransaction<'a, S>
 {
     type Output = Result<FinalExecutionOutcomeView>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
@@ -179,5 +162,22 @@ impl<'a, S: Signer + ExposeAccountId + 'static> std::future::IntoFuture
                 )
                 .await
         })
+    }
+}
+
+impl Client {
+    /// Start calling into a contract on a specific function.
+    pub fn call<S: Signer + ExposeAccountId>(
+        &self,
+        signer: S,
+        contract_id: &AccountId,
+        function: &str,
+    ) -> FunctionCallTransaction<'_, S> {
+        FunctionCallTransaction {
+            client: self,
+            signer,
+            contract_id: contract_id.clone(),
+            function: Function::new(function),
+        }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,12 +1,16 @@
 use near_account_id::AccountId;
-use near_crypto::Signer;
+use near_crypto::{PublicKey, Signer};
 use near_gas::NearGas;
+use near_primitives::account::AccessKey;
 use near_primitives::borsh;
-use near_primitives::transaction::FunctionCallAction;
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::{
+    Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
+    DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
+};
 use near_primitives::views::FinalExecutionOutcomeView;
 use near_token::NearToken;
 
-use crate::query::BoxFuture;
 use crate::signer::ExposeAccountId;
 use crate::{Client, Error, Result};
 
@@ -99,7 +103,7 @@ impl Function {
 pub struct FunctionCallTransaction<'a, S> {
     pub(crate) client: &'a Client,
     pub(crate) signer: S,
-    pub(crate) contract_id: AccountId,
+    pub(crate) receiver_id: AccountId,
     pub(crate) function: Function,
 }
 
@@ -146,27 +150,193 @@ impl<S> FunctionCallTransaction<'_, S> {
     }
 }
 
-impl<'a, S: Signer + ExposeAccountId + 'static> std::future::IntoFuture
-    for FunctionCallTransaction<'a, S>
+impl<'a, S> FunctionCallTransaction<'a, S>
+where
+    S: Signer + ExposeAccountId + 'static,
 {
-    type Output = Result<FinalExecutionOutcomeView>;
-    type IntoFuture = BoxFuture<'a, Self::Output>;
+    /// Process the transaction, and return the result of the execution.
+    pub async fn transact(self) -> Result<FinalExecutionOutcomeView> {
+        self.client
+            .send_tx(
+                &self.signer,
+                &self.receiver_id,
+                vec![self.function.into_action()?.into()],
+            )
+            .await
+    }
 
-    fn into_future(self) -> Self::IntoFuture {
-        Box::pin(async move {
-            self.client
-                .send_tx(
-                    &self.signer,
-                    &self.contract_id,
-                    vec![self.function.into_action()?.into()],
-                )
-                .await
-        })
+    /// Send the transaction to the network to be processed. This will be done asynchronously
+    /// without waiting for the transaction to complete. This returns us a [`TransactionStatus`]
+    /// for which we can call into [`status`] and/or `.await` to retrieve info about whether
+    /// the transaction has been completed or not. Note that `.await` will wait till completion
+    /// of the transaction.
+    pub async fn transact_async(self) -> Result<CryptoHash> {
+        self.client
+            .send_tx_async(
+                &self.signer,
+                &self.receiver_id,
+                vec![self.function.into_action()?.into()],
+            )
+            .await
+    }
+}
+
+/// A builder-like object that will allow specifying various actions to be performed
+/// in a single transaction. For details on each of the actions, find them in
+/// [NEAR transactions](https://docs.near.org/docs/concepts/transaction).
+///
+/// All actions are performed on the account specified by `receiver_id`.
+pub struct Transaction<'a, S> {
+    client: &'a Client,
+    signer: S,
+    receiver_id: AccountId,
+    // Result used to defer errors in argument parsing to later when calling into transact
+    actions: Result<Vec<Action>>,
+}
+
+impl<'a, S> Transaction<'a, S>
+where
+    S: Signer + ExposeAccountId + 'static,
+{
+    pub(crate) fn new(client: &'a Client, signer: S, receiver_id: AccountId) -> Self {
+        Self {
+            client,
+            signer,
+            receiver_id,
+            actions: Ok(Vec::new()),
+        }
+    }
+
+    /// Process the transaction, and return the result of the execution.
+    pub async fn transact(self) -> Result<FinalExecutionOutcomeView> {
+        self.client
+            .send_tx(&self.signer, &self.receiver_id, self.actions?)
+            .await
+    }
+
+    /// Send the transaction to the network to be processed. This will be done asynchronously
+    /// without waiting for the transaction to complete. This returns us a [`TransactionStatus`]
+    /// for which we can call into [`status`] and/or `.await` to retrieve info about whether
+    /// the transaction has been completed or not. Note that `.await` will wait till completion
+    /// of the transaction.
+    ///
+    /// [`status`]: TransactionStatus::status
+    pub async fn transact_async(self) -> Result<CryptoHash> {
+        self.client
+            .send_tx_async(&self.signer, &self.receiver_id, self.actions?)
+            .await
+    }
+}
+
+impl<S> Transaction<'_, S> {
+    /// Adds a key to the `receiver_id`'s account, where the public key can be used
+    /// later to delete the same key.
+    pub fn add_key(mut self, pk: PublicKey, ak: AccessKey) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(
+                AddKeyAction {
+                    public_key: pk.into(),
+                    access_key: ak.into(),
+                }
+                .into(),
+            );
+        }
+
+        self
+    }
+
+    /// Call into the `receiver_id`'s contract with the specific function arguments.
+    pub fn call(mut self, function: Function) -> Self {
+        let args = match function.args {
+            Ok(args) => args,
+            Err(err) => {
+                self.actions = Err(err);
+                return self;
+            }
+        };
+
+        if let Ok(actions) = &mut self.actions {
+            actions.push(Action::FunctionCall(FunctionCallAction {
+                method_name: function.name.to_string(),
+                args,
+                deposit: function.deposit.as_yoctonear(),
+                gas: function.gas.as_gas(),
+            }));
+        }
+
+        self
+    }
+
+    /// Create a new account with the account id being `receiver_id`.
+    pub fn create_account(mut self) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(CreateAccountAction {}.into());
+        }
+        self
+    }
+
+    /// Deletes the `receiver_id`'s account. The beneficiary specified by
+    /// `beneficiary_id` will receive the funds of the account deleted.
+    pub fn delete_account(mut self, beneficiary_id: &AccountId) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(
+                DeleteAccountAction {
+                    beneficiary_id: beneficiary_id.clone(),
+                }
+                .into(),
+            );
+        }
+        self
+    }
+
+    /// Deletes a key from the `receiver_id`'s account, where the public key is
+    /// associated with the access key to be deleted.
+    pub fn delete_key(mut self, pk: PublicKey) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(DeleteKeyAction { public_key: pk }.into());
+        }
+        self
+    }
+
+    /// Deploy contract code or WASM bytes to the `receiver_id`'s account.
+    pub fn deploy(mut self, code: &[u8]) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(DeployContractAction { code: code.into() }.into());
+        }
+        self
+    }
+
+    /// An action which stakes the signer's tokens and setups a validator public key.
+    pub fn stake(mut self, stake: NearToken, pk: PublicKey) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(
+                StakeAction {
+                    stake: stake.as_yoctonear(),
+                    public_key: pk,
+                }
+                .into(),
+            );
+        }
+        self
+    }
+
+    /// Transfer `deposit` amount from `signer`'s account into `receiver_id`'s account.
+    pub fn transfer(mut self, deposit: NearToken) -> Self {
+        if let Ok(actions) = &mut self.actions {
+            actions.push(
+                TransferAction {
+                    deposit: deposit.as_yoctonear(),
+                }
+                .into(),
+            );
+        }
+        self
     }
 }
 
 impl Client {
-    /// Start calling into a contract on a specific function.
+    /// Start calling into a contract on a specific function. Returns a [`FunctionCallTransaction`]
+    /// object where we can use to add more parameters such as the arguments, deposit, and gas.
     pub fn call<S: Signer + ExposeAccountId>(
         &self,
         signer: S,
@@ -176,8 +346,20 @@ impl Client {
         FunctionCallTransaction {
             client: self,
             signer,
-            contract_id: contract_id.clone(),
+            receiver_id: contract_id.clone(),
             function: Function::new(function),
         }
+    }
+
+    /// Start a batch transaction. Returns a [`Transaction`] object that we can
+    /// use to add Actions to the batched transaction. Call `transact` to send
+    /// the batched transaction to the network.
+    pub fn batch<S: Signer + ExposeAccountId + 'static>(
+        &self,
+        signer: S,
+        contract_id: &AccountId,
+        function: &str,
+    ) -> Transaction<'_, S> {
+        Transaction::new(self, signer, contract_id.clone()).call(Function::new(function))
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,8 +1,14 @@
+use near_account_id::AccountId;
+use near_crypto::Signer;
 use near_gas::NearGas;
 use near_primitives::borsh;
+use near_primitives::transaction::FunctionCallAction;
+use near_primitives::views::FinalExecutionOutcomeView;
 use near_token::NearToken;
 
-use crate::{Error, Result};
+use crate::query::BoxFuture;
+use crate::signer::ExposeAccountId;
+use crate::{Client, Error, Result};
 
 pub const MAX_GAS: NearGas = NearGas::from_tgas(300);
 pub const DEFAULT_CALL_FN_GAS: NearGas = NearGas::from_tgas(10);
@@ -78,5 +84,100 @@ impl Function {
     /// Use the maximum amount of gas possible to perform this function call into the contract.
     pub fn max_gas(self) -> Self {
         self.gas(MAX_GAS)
+    }
+
+    pub(crate) fn into_action(self) -> Result<FunctionCallAction> {
+        Ok(FunctionCallAction {
+            args: self.args?,
+            method_name: self.name,
+            gas: self.gas.as_gas(),
+            deposit: self.deposit.as_yoctonear(),
+        })
+    }
+}
+
+pub struct CallableFunction<'a, S> {
+    pub(crate) client: &'a Client,
+    pub(crate) signer: S,
+    pub(crate) contract_id: AccountId,
+    pub(crate) function: Function,
+}
+
+impl<S> CallableFunction<'_, S> {
+    /// Provide the arguments for the call. These args are serialized bytes from either
+    /// a JSON or Borsh serializable set of arguments. To use the more specific versions
+    /// with better quality of life, use `args_json` or `args_borsh`.
+    pub fn args(mut self, args: Vec<u8>) -> Self {
+        self.function = self.function.args(args);
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is JSON serializable and can be
+    /// accepted by the equivalent contract. Recommend to use something like
+    /// `serde_json::json!` macro to easily serialize the arguments.
+    pub fn args_json<U: serde::Serialize>(mut self, args: U) -> Self {
+        self.function = self.function.args_json(args);
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is borsh serializable and can be
+    /// accepted by the equivalent contract.
+    pub fn args_borsh<U: borsh::BorshSerialize>(mut self, args: U) -> Self {
+        self.function = self.function.args_borsh(args);
+        self
+    }
+
+    /// Specify the amount of tokens to be deposited where `deposit` is the amount of
+    /// tokens in yocto near.
+    pub fn deposit(mut self, deposit: NearToken) -> Self {
+        self.function = self.function.deposit(deposit);
+        self
+    }
+
+    /// Specify the amount of gas to be used.
+    pub fn gas(mut self, gas: NearGas) -> Self {
+        self.function = self.function.gas(gas);
+        self
+    }
+
+    /// Use the maximum amount of gas possible to perform this function call into the contract.
+    pub fn max_gas(self) -> Self {
+        self.gas(MAX_GAS)
+    }
+}
+
+impl Client {
+    /// Start calling into a contract on a specific function.
+    pub fn call<S: Signer + ExposeAccountId>(
+        &self,
+        signer: S,
+        contract_id: &AccountId,
+        function: &str,
+    ) -> CallableFunction<'_, S> {
+        CallableFunction {
+            client: self,
+            signer,
+            contract_id: contract_id.clone(),
+            function: Function::new(function),
+        }
+    }
+}
+
+impl<'a, S: Signer + ExposeAccountId + 'static> std::future::IntoFuture
+    for CallableFunction<'a, S>
+{
+    type Output = Result<FinalExecutionOutcomeView>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            self.client
+                .send_tx(
+                    &self.signer,
+                    &self.contract_id,
+                    vec![self.function.into_action()?.into()],
+                )
+                .await
+        })
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,551 @@
+//! This module defines a bunch of internal types used solely for querying into RPC
+//! methods to retrieve info about what's on the chain. Note that the types defined
+//! are exposed as-is for users to reference in their own functions or structs as
+//! needed. These types cannot be created outside of near_fetch.
+
+use std::fmt::{Debug, Display};
+
+use near_account_id::AccountId;
+use near_crypto::PublicKey;
+use near_jsonrpc_client::methods::query::RpcQueryResponse;
+use near_jsonrpc_client::methods::{self, RpcMethod};
+use near_jsonrpc_primitives::types::chunks::ChunkReference;
+use near_jsonrpc_primitives::types::query::QueryResponseKind;
+use near_primitives::borsh;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockHeight, BlockId, BlockReference, Finality, ShardId, StoreKey};
+use near_primitives::views::{
+    AccessKeyList, AccessKeyView, AccountView, BlockView, CallResult, ChunkView, QueryRequest,
+    ViewStateResult,
+};
+use near_token::NearToken;
+
+use crate::ops::Function;
+use crate::{Client, Error, Result};
+
+/// Intenral type used to represent a boxed future.
+type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// `Query` object allows creating queries into the network of our choice. This object is
+/// usually given from making calls from other functions such as [`view_state`].
+///
+/// [`view_state`]: crate::worker::Worker::view_state
+pub struct Query<'a, T> {
+    pub(crate) method: T,
+    pub(crate) client: &'a Client,
+    pub(crate) block_ref: Option<BlockReference>,
+}
+
+impl<'a, T> Query<'a, T> {
+    pub(crate) fn new(client: &'a Client, method: T) -> Self {
+        Self {
+            method,
+            client,
+            block_ref: None,
+        }
+    }
+
+    /// Specify at which block height to query from. Note that only archival
+    /// networks will have the full history while networks like mainnet or testnet will
+    /// only have the history from 5 or less epochs ago.
+    pub fn block_height(mut self, height: BlockHeight) -> Self {
+        self.block_ref = Some(BlockId::Height(height).into());
+        self
+    }
+
+    /// Specify at which block hash to query from. Note that only archival
+    /// networks will have the full history while networks like mainnet or testnet will
+    /// only have the history from 5 or less epochs ago.
+    pub fn block_hash(mut self, hash: CryptoHash) -> Self {
+        self.block_ref = Some(BlockId::Hash(near_primitives::hash::CryptoHash(hash.0)).into());
+        self
+    }
+}
+
+// Constrained to RpcQueryRequest, since methods like GasPrice only take block_id but not Finality.
+impl<'a, T> Query<'a, T>
+where
+    T: ProcessQuery<Method = methods::query::RpcQueryRequest>,
+{
+    /// Specify at which block [`Finality`] to query from.
+    pub fn finality(mut self, value: Finality) -> Self {
+        self.block_ref = Some(value.into());
+        self
+    }
+}
+
+impl<'a, T, R> std::future::IntoFuture for Query<'a, T>
+where
+    T: ProcessQuery<Output = R> + Send + Sync + 'static,
+    <T as ProcessQuery>::Method: RpcMethod + Debug + Send + Sync,
+    <<T as ProcessQuery>::Method as RpcMethod>::Response: Debug + Send + Sync,
+    <<T as ProcessQuery>::Method as RpcMethod>::Error: Debug + Display + Send + Sync,
+{
+    type Output = Result<R>;
+
+    // TODO: boxed future required due to impl Trait as type alias being unstable. So once
+    // https://github.com/rust-lang/rust/issues/63063 is resolved, we can move to that instead.
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let block_reference = self.block_ref.unwrap_or_else(BlockReference::latest);
+            let resp = self
+                .client
+                .send(self.method.into_request(block_reference)?)
+                .await
+                .map_err(|err| Error::Rpc(err.into()))?;
+
+            T::from_response(resp)
+        })
+    }
+}
+
+// Note: this trait is exposed publicly due to constraining with the impl offering `finality`.
+/// Trait used as a converter from WorkspaceRequest to near-rpc request, and from near-rpc
+/// response to a WorkspaceResult. Mostly used internally to facilitate syntax sugar for performing
+/// RPC requests with async builders.
+pub trait ProcessQuery {
+    // TODO: associated default type is unstable. So for now, will require writing
+    // the manual impls for query_request
+    /// Method for doing the internal RPC request to the network of our choosing.
+    type Method: RpcMethod;
+
+    /// Expected output after performing a query. This is mainly to convert over
+    /// the type from near-primitives to a workspace type.
+    type Output;
+
+    /// Convert into the Request object that is required to perform the RPC request.
+    fn into_request(self, block_ref: BlockReference) -> Result<Self::Method>;
+
+    /// Convert the response from the RPC request to a type of our choosing, mainly to conform
+    /// to workspaces related types from the near-primitives or json types from the network.
+    fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output>;
+}
+
+pub struct ViewFunction {
+    pub(crate) account_id: AccountId,
+    pub(crate) function: Function,
+}
+
+pub struct ViewCode {
+    pub(crate) account_id: AccountId,
+}
+
+pub struct ViewAccount {
+    pub(crate) account_id: AccountId,
+}
+
+pub struct ViewBlock;
+
+pub struct ViewState {
+    account_id: AccountId,
+    prefix: Option<Vec<u8>>,
+}
+
+pub struct ViewAccessKey {
+    pub(crate) account_id: AccountId,
+    pub(crate) public_key: PublicKey,
+}
+
+pub struct ViewAccessKeyList {
+    pub(crate) account_id: AccountId,
+}
+
+pub struct GasPrice;
+
+impl ProcessQuery for ViewFunction {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = CallResult;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::CallFunction {
+                account_id: self.account_id,
+                method_name: self.function.name,
+                args: self.function.args?.into(),
+            },
+        })
+    }
+
+    fn from_response(resp: RpcQueryResponse) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::CallResult(result) => Ok(result),
+            _ => Err(Error::RpcReturnedInvalidData(
+                "while querying account".into(),
+            )),
+        }
+    }
+}
+
+// Specific builder methods attached to a ViewFunction.
+impl Query<'_, ViewFunction> {
+    /// Provide the arguments for the call. These args are serialized bytes from either
+    /// a JSON or Borsh serializable set of arguments. To use the more specific versions
+    /// with better quality of life, use `args_json` or `args_borsh`.
+    pub fn args(mut self, args: Vec<u8>) -> Self {
+        self.method.function = self.method.function.args(args);
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is JSON serializable and can be
+    /// accepted by the equivalent contract. Recommend to use something like
+    /// `serde_json::json!` macro to easily serialize the arguments.
+    pub fn args_json<U: serde::Serialize>(mut self, args: U) -> Self {
+        self.method.function = self.method.function.args_json(args);
+        self
+    }
+
+    /// Similar to `args`, specify an argument that is borsh serializable and can be
+    /// accepted by the equivalent contract.
+    pub fn args_borsh<U: borsh::BorshSerialize>(mut self, args: U) -> Self {
+        self.method.function = self.method.function.args_borsh(args);
+        self
+    }
+}
+
+impl ProcessQuery for ViewCode {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = Vec<u8>;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::ViewCode {
+                account_id: self.account_id,
+            },
+        })
+    }
+
+    fn from_response(resp: RpcQueryResponse) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::ViewCode(contract) => Ok(contract.code),
+            _ => Err(Error::RpcReturnedInvalidData("while querying code".into())),
+        }
+    }
+}
+
+impl ProcessQuery for ViewAccount {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = AccountView;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::ViewAccount {
+                account_id: self.account_id,
+            },
+        })
+    }
+
+    fn from_response(resp: RpcQueryResponse) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::ViewAccount(account) => Ok(account),
+            _ => Err(Error::RpcReturnedInvalidData(
+                "while querying account".into(),
+            )),
+        }
+    }
+}
+
+impl ProcessQuery for ViewBlock {
+    type Method = methods::block::RpcBlockRequest;
+    type Output = BlockView;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method { block_reference })
+    }
+
+    fn from_response(view: BlockView) -> Result<Self::Output> {
+        Ok(view)
+    }
+}
+
+impl ProcessQuery for ViewState {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = ViewStateResult;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::ViewState {
+                account_id: self.account_id,
+                prefix: StoreKey::from(self.prefix.map(Vec::from).unwrap_or_default()),
+                include_proof: false,
+            },
+        })
+    }
+
+    fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::ViewState(state) => Ok(state),
+            _ => Err(Error::RpcReturnedInvalidData("while querying state".into())),
+        }
+    }
+}
+
+impl<'a> Query<'a, ViewState> {
+    pub(crate) fn view_state(client: &'a Client, id: &AccountId) -> Self {
+        Self::new(
+            client,
+            ViewState {
+                account_id: id.clone(),
+                prefix: None,
+            },
+        )
+    }
+
+    /// Set the prefix for viewing the state.
+    pub fn prefix(mut self, value: &[u8]) -> Self {
+        self.method.prefix = Some(value.into());
+        self
+    }
+}
+
+impl ProcessQuery for ViewAccessKey {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = AccessKeyView;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::ViewAccessKey {
+                account_id: self.account_id,
+                public_key: self.public_key,
+            },
+        })
+    }
+
+    fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::AccessKey(key) => Ok(key),
+            _ => Err(Error::RpcReturnedInvalidData(
+                "while querying access key".into(),
+            )),
+        }
+    }
+}
+
+impl ProcessQuery for ViewAccessKeyList {
+    type Method = methods::query::RpcQueryRequest;
+    type Output = AccessKeyList;
+
+    fn into_request(self, block_reference: BlockReference) -> Result<Self::Method> {
+        Ok(Self::Method {
+            block_reference,
+            request: QueryRequest::ViewAccessKeyList {
+                account_id: self.account_id,
+            },
+        })
+    }
+
+    fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output> {
+        match resp.kind {
+            QueryResponseKind::AccessKeyList(keylist) => Ok(keylist),
+            _ => Err(Error::RpcReturnedInvalidData(
+                "while querying access keys".into(),
+            )),
+        }
+    }
+}
+
+impl ProcessQuery for GasPrice {
+    type Method = methods::gas_price::RpcGasPriceRequest;
+    type Output = NearToken;
+
+    fn into_request(self, block_ref: BlockReference) -> Result<Self::Method> {
+        let block_id = match block_ref {
+            // User provided input via `block_hash` or `block_height` functions.
+            BlockReference::BlockId(block_id) => Some(block_id),
+            // default case, set by `Query` struct via BlockReference::latest.
+            BlockReference::Finality(_finality) => None,
+            // Should not be reachable, unless code got changed.
+            BlockReference::SyncCheckpoint(point) => {
+                return Err(Error::RpcReturnedInvalidData(format!(
+                    "Cannot supply sync checkpoint to gas price: {point:?}. Potential API bug?"
+                )))
+            }
+        };
+
+        Ok(Self::Method { block_id })
+    }
+
+    fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output> {
+        Ok(NearToken::from_yoctonear(resp.gas_price))
+    }
+}
+
+/// Query object used to query for chunk related details at a specific `ChunkReference` which
+/// consists of either a chunk [`CryptoHash`], or a `BlockShardId` (which consists of [`ShardId`]
+/// and either block [`CryptoHash`] or [`BlockHeight`]).
+///
+/// The default behavior where a `ChunkReference` is not supplied will use a `BlockShardId`
+/// referencing the latest block `CryptoHash` with `ShardId` of 0.
+pub struct QueryChunk<'a> {
+    client: &'a Client,
+    chunk_ref: Option<ChunkReference>,
+}
+
+impl<'a> QueryChunk<'a> {
+    pub(crate) fn new(client: &'a Client) -> Self {
+        Self {
+            client,
+            chunk_ref: None,
+        }
+    }
+
+    /// Specify at which block hash and shard id to query the chunk from. Note that only
+    /// archival networks will have the full history while networks like mainnet or testnet
+    /// will only have the history from 5 or less epochs ago.
+    pub fn block_hash_and_shard(mut self, hash: CryptoHash, shard_id: ShardId) -> Self {
+        self.chunk_ref = Some(ChunkReference::BlockShardId {
+            block_id: BlockId::Hash(near_primitives::hash::CryptoHash(hash.0)),
+            shard_id,
+        });
+        self
+    }
+
+    /// Specify at which block height and shard id to query the chunk from. Note that only
+    /// archival networks will have the full history while networks like mainnet or testnet
+    /// will only have the history from 5 or less epochs ago.
+    pub fn block_height_and_shard(mut self, height: BlockHeight, shard_id: ShardId) -> Self {
+        self.chunk_ref = Some(ChunkReference::BlockShardId {
+            block_id: BlockId::Height(height),
+            shard_id,
+        });
+        self
+    }
+
+    /// Specify at which chunk hash to query the chunk from.
+    pub fn chunk_hash(mut self, hash: CryptoHash) -> Self {
+        self.chunk_ref = Some(ChunkReference::ChunkHash {
+            chunk_id: near_primitives::hash::CryptoHash(hash.0),
+        });
+        self
+    }
+}
+
+impl<'a> std::future::IntoFuture for QueryChunk<'a> {
+    type Output = Result<ChunkView>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let chunk_reference = if let Some(chunk_ref) = self.chunk_ref {
+                chunk_ref
+            } else {
+                // Use the latest block hash in the case the user doesn't supply the ChunkReference. Note that
+                // shard_id 0 is used in the default case.
+                let block_view = self.client.view_block().await?;
+                ChunkReference::BlockShardId {
+                    block_id: BlockId::Hash(block_view.header.hash),
+                    shard_id: 0,
+                }
+            };
+
+            let chunk_view = self
+                .client
+                .send(methods::chunk::RpcChunkRequest { chunk_reference })
+                .await?;
+
+            Ok(chunk_view)
+        })
+    }
+}
+
+impl Client {
+    /// Call into a contract's view function. Returns a [`Query`] which allows us
+    /// to specify further details like the arguments of the view call, or at what
+    /// point in the chain we want to view.
+    pub fn view(&self, contract_id: &AccountId, function: &str) -> Query<'_, ViewFunction> {
+        Query::new(
+            self,
+            ViewFunction {
+                account_id: contract_id.clone(),
+                function: Function::new(function),
+            },
+        )
+    }
+
+    /// View the WASM code bytes of a contract on the network.
+    pub fn view_code(&self, contract_id: &AccountId) -> Query<'_, ViewCode> {
+        Query::new(
+            self,
+            ViewCode {
+                account_id: contract_id.clone(),
+            },
+        )
+    }
+
+    /// View the state of a account/contract on the network. This will return the internal
+    /// state of the account in the form of a map of key-value pairs; where STATE contains
+    /// info on a contract's internal data.
+    pub fn view_state(&self, contract_id: &AccountId) -> Query<'_, ViewState> {
+        Query::view_state(self, contract_id)
+    }
+
+    /// View the block from the network. Supply additional parameters such as [`block_height`]
+    /// or [`block_hash`] to get the block.
+    ///
+    /// [`block_height`]: Query::block_height
+    /// [`block_hash`]: Query::block_hash
+    pub fn view_block(&self) -> Query<'_, ViewBlock> {
+        Query::new(self, ViewBlock)
+    }
+
+    /// View the chunk from the network once awaited. Supply additional parameters such as
+    /// [`block_hash_and_shard`], [`block_height_and_shard`] or [`chunk_hash`] to get the
+    /// chunk at a specific reference point. If none of those are supplied, the default
+    /// reference point will be used, which will be the latest block_hash with a shard_id
+    /// of 0.
+    ///
+    /// [`block_hash_and_shard`]: QueryChunk::block_hash_and_shard
+    /// [`block_height_and_shard`]: QueryChunk::block_height_and_shard
+    /// [`chunk_hash`]: QueryChunk::chunk_hash
+    pub fn view_chunk(&self) -> QueryChunk<'_> {
+        QueryChunk::new(self)
+    }
+
+    /// Views the [`AccessKey`] of the account specified by [`AccountId`] associated with
+    /// the [`PublicKey`]
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_key(&self, id: &AccountId, pk: &PublicKey) -> Query<'_, ViewAccessKey> {
+        Query::new(
+            self,
+            ViewAccessKey {
+                account_id: id.clone(),
+                public_key: pk.clone(),
+            },
+        )
+    }
+
+    /// Views all the [`AccessKey`]s of the account specified by [`AccountId`]. This will
+    /// return a list of [`AccessKey`]s along with the associated [`PublicKey`].
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_keys(&self, id: &AccountId) -> Query<'_, ViewAccessKeyList> {
+        Query::new(
+            self,
+            ViewAccessKeyList {
+                account_id: id.clone(),
+            },
+        )
+    }
+
+    /// View account details of a specific account on the network.
+    pub fn view_account(&self, account_id: &AccountId) -> Query<'_, ViewAccount> {
+        Query::new(
+            self,
+            ViewAccount {
+                account_id: account_id.clone(),
+            },
+        )
+    }
+
+    /// Fetches the latest gas price on the network.
+    pub fn gas_price(&self) -> Query<'_, GasPrice> {
+        Query::new(self, GasPrice)
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -24,7 +24,8 @@ use crate::ops::Function;
 use crate::{Client, Error, Result};
 
 /// Intenral type used to represent a boxed future.
-type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+pub(crate) type BoxFuture<'a, T> =
+    std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
 /// `Query` object allows creating queries into the network of our choice. This object is
 /// usually given from making calls from other functions such as [`view_state`].

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 
 /// A key rotating in memory signer, that will rotate the key used for signing on
 /// each call to [`Signer::sign`].
+#[derive(Clone)]
 pub struct KeyRotatingSigner {
     signers: Arc<Vec<InMemorySigner>>,
     counter: Arc<AtomicUsize>,
@@ -53,15 +54,6 @@ impl KeyRotatingSigner {
 
     pub fn public_key(&self) -> &PublicKey {
         &self.current_signer().public_key
-    }
-}
-
-impl Clone for KeyRotatingSigner {
-    fn clone(&self) -> Self {
-        Self {
-            signers: self.signers.clone(),
-            counter: self.counter.clone(),
-        }
     }
 }
 


### PR DESCRIPTION
Added:
- `Client::view_*` functions which gives the `Query` objects exactly the same ones from `workspaces-rs`
- `Client::call` and `Client::batch` for high level calls into sending transactions.

All these added functions are builder-like and provide consistent APIs to send requests to the network.