### PR TITLE
Added high level ViewResult type

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -235,8 +235,8 @@ impl<S> Transaction<'_, S> {
         if let Ok(actions) = &mut self.actions {
             actions.push(
                 AddKeyAction {
-                    public_key: pk.into(),
-                    access_key: ak.into(),
+                    public_key: pk,
+                    access_key: ak,
                 }
                 .into(),
             );


### PR DESCRIPTION
**breaking** `Client::view` function returns high level `ViewResult` now for `json`/`borsh` easy deserialization