### PR TITLE
feat: high level async tx result

### DIFF
--- a/near-fetch/src/lib.rs
+++ b/near-fetch/src/lib.rs
@@ -3,8 +3,6 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use ops::RetryableTransaction;
-use signer::SignerExt;
 use tokio::sync::RwLock;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
@@ -33,6 +31,8 @@ pub mod result;
 pub mod signer;
 
 use crate::error::Result;
+use crate::ops::RetryableTransaction;
+use crate::signer::SignerExt;
 
 pub use crate::error::Error;
 

--- a/near-fetch/src/lib.rs
+++ b/near-fetch/src/lib.rs
@@ -4,8 +4,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
-use tokio_retry::Retry;
 
 use near_account_id::AccountId;
 use near_crypto::PublicKey;
@@ -162,13 +160,13 @@ impl Client {
     }
 
     /// Send a JsonRpc method to the network.
-    pub(crate) async fn send<M>(&self, method: M) -> MethodCallResult<M::Response, M::Error>
+    pub(crate) async fn send_query<M>(&self, method: &M) -> MethodCallResult<M::Response, M::Error>
     where
         M: methods::RpcMethod + Send + Sync,
         M::Response: Send,
         M::Error: Send,
     {
-        retry(|| async { self.rpc_client.call(&method).await }).await
+        self.rpc_client.call(method).await
     }
 
     /// Fetches the nonce associated to the account id and public key, which essentially is the
@@ -313,15 +311,4 @@ async fn fetch_nonce(
             }
         }
     }
-}
-
-async fn retry<R, E, T, F>(task: F) -> T::Output
-where
-    F: FnMut() -> T,
-    T: core::future::Future<Output = core::result::Result<R, E>>,
-{
-    // Exponential backoff starting w/ 5ms for maximum retry of 4 times with the following delays:
-    //   5, 25, 125, 625 ms
-    let retry_strategy = ExponentialBackoff::from_millis(5).map(jitter).take(4);
-    Retry::spawn(retry_strategy, task).await
 }

--- a/near-fetch/src/ops.rs
+++ b/near-fetch/src/ops.rs
@@ -202,7 +202,7 @@ impl<'a, 'b> FunctionCallTransaction<'a, 'b> {
     /// Retry this transactions if it fails. This will retry the transaction with exponential
     /// backoff.
     pub fn retry_exponential(self, base_millis: u64, max_retries: usize) -> Self {
-        self.retry_with(
+        self.retry(
             ExponentialBackoff::from_millis(base_millis)
                 .map(jitter)
                 .take(max_retries),
@@ -211,7 +211,7 @@ impl<'a, 'b> FunctionCallTransaction<'a, 'b> {
 
     /// Retry this transactions if it fails. This will retry the transaction with the provided
     /// retry strategy.
-    pub fn retry_with(
+    pub fn retry(
         mut self,
         strategy: impl Iterator<Item = Duration> + Send + Sync + 'static,
     ) -> Self {

--- a/near-fetch/src/query.rs
+++ b/near-fetch/src/query.rs
@@ -93,7 +93,7 @@ where
             let block_reference = self.block_ref.unwrap_or_else(BlockReference::latest);
             let resp = self
                 .client
-                .send(self.method.into_request(block_reference)?)
+                .send_query(&self.method.into_request(block_reference)?)
                 .await
                 .map_err(|err| Error::Rpc(err.into()))?;
 
@@ -444,7 +444,7 @@ impl<'a> std::future::IntoFuture for QueryChunk<'a> {
 
             let chunk_view = self
                 .client
-                .send(methods::chunk::RpcChunkRequest { chunk_reference })
+                .send_query(&methods::chunk::RpcChunkRequest { chunk_reference })
                 .await?;
 
             Ok(chunk_view)

--- a/near-fetch/src/query.rs
+++ b/near-fetch/src/query.rs
@@ -30,7 +30,7 @@ pub(crate) type BoxFuture<'a, T> =
 /// `Query` object allows creating queries into the network of our choice. This object is
 /// usually given from making calls from other functions such as [`view_state`].
 ///
-/// [`view_state`]: crate::worker::Worker::view_state
+/// [`view_state`]: Client::view_state
 pub struct Query<'a, T> {
     pub(crate) method: T,
     pub(crate) client: &'a Client,
@@ -103,24 +103,21 @@ where
 }
 
 // Note: this trait is exposed publicly due to constraining with the impl offering `finality`.
-/// Trait used as a converter from WorkspaceRequest to near-rpc request, and from near-rpc
-/// response to a WorkspaceResult. Mostly used internally to facilitate syntax sugar for performing
-/// RPC requests with async builders.
+/// Trait used as a high level APIs for consistent usages of block reference. Mostly used
+/// internally to facilitate syntax sugar for performing RPC requests with async builders.
 pub trait ProcessQuery {
     // TODO: associated default type is unstable. So for now, will require writing
     // the manual impls for query_request
     /// Method for doing the internal RPC request to the network of our choosing.
     type Method: RpcMethod;
 
-    /// Expected output after performing a query. This is mainly to convert over
-    /// the type from near-primitives to a workspace type.
+    /// Expected output after performing a query.
     type Output;
 
     /// Convert into the Request object that is required to perform the RPC request.
     fn into_request(self, block_ref: BlockReference) -> Result<Self::Method>;
 
-    /// Convert the response from the RPC request to a type of our choosing, mainly to conform
-    /// to workspaces related types from the near-primitives or json types from the network.
+    /// Convert the response from the RPC request to a type of our choosing.
     fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output>;
 }
 


### PR DESCRIPTION
Added `AsyncTransactionStatus` for high level calls into it after the broadcasting a transaction asynchronously through `Client::send_tx_async` or `{FunctionCallTransaction, Transaction}::transact_async`