### PR TITLE
release: 0.2.0

### DIFF
--- a/near-fetch/Cargo.toml
+++ b/near-fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-fetch"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Added

- https://github.com/ChaoticTempest/fetch/pull/5
- https://github.com/ChaoticTempest/fetch/pull/7
-  https://github.com/ChaoticTempest/fetch/pull/8
- https://github.com/ChaoticTempest/fetch/pull/9
  - **breaking** `Client::send_tx` no longer defaults to retrying. Need to explicitly call `.retry` or `.retry_exponential` after `Client::send_tx` now.
- https://github.com/ChaoticTempest/fetch/pull/10