### PR TITLE
fix: wait_until parameter defaults for TxExecutionStatus

### DIFF
--- a/near-fetch/src/query.rs
+++ b/near-fetch/src/query.rs
@@ -592,7 +592,7 @@ impl Client {
         tx_hash: CryptoHash,
         wait_until: Option<TxExecutionStatus>,
     ) -> Result<FinalExecutionOutcomeView, Error> {
-        let wait_until_param = wait_until.unwrap_or(TxExecutionStatus::Executed);
+        let wait_until = wait_until.unwrap_or_default();
 
         let response = self
             .rpc_client
@@ -601,7 +601,7 @@ impl Client {
                     sender_account_id: sender_id.clone(),
                     tx_hash,
                 },
-                wait_until: wait_until_param,
+                wait_until,
             })
             .await
             .map_err(Error::RpcTransactionError)?;


### PR DESCRIPTION
This fixes the issues with the defaults `TxExecutionStatus` being used for `wait_until` parameter